### PR TITLE
Correct path for SET requrst option

### DIFF
--- a/frontend/src/sections/devices/usp/devices-discovery.js
+++ b/frontend/src/sections/devices/usp/devices-discovery.js
@@ -1045,7 +1045,7 @@ const getDeviceParameterInstances = async (raw) =>{
     let parameterToChange;
     console.log("params",params)
     parameterToChange = params.pop()
-    objToChange = params.join(".")
+    objToChange = params.join(".") + "."
 
     var requestOptions = {
         method: 'PUT',


### PR DESCRIPTION
While sending SET request, the object path does not consist "." at the end.
I think that is causing the issue. But not sure why the "dot" is missing,
From Oktopus Controller :
2025 Feb 21 08:48:54 prplOS obuspa[1696]: header {
 2025 Feb 21 08:48:54 prplOS obuspa[1696]:  msg_id: "9081e357-feb1-48be-9f84-3c43d0280cca"
 2025 Feb 21 08:48:54 prplOS obuspa[1696]:  msg_type: SET
 2025 Feb 21 08:48:54 prplOS obuspa[1696]: }
 2025 Feb 21 08:48:54 prplOS obuspa[1696]: body {
 2025 Feb 21 08:48:54 prplOS obuspa[1696]:  request {
 2025 Feb 21 08:48:54 prplOS obuspa[1696]:    set {
 2025 Feb 21 08:48:54 prplOS obuspa[1696]:      allow_partial: true
 2025 Feb 21 08:48:54 prplOS obuspa[1696]:      update_objs {
 2025 Feb 21 08:48:54 prplOS obuspa[1696]:        obj_path: "Device.Time.Client.1"
 2025 Feb 21 08:48:54 prplOS obuspa[1696]:        param_settings {
 2025 Feb 21 08:48:54 prplOS obuspa[1696]:          param: "Servers"
 2025 Feb 21 08:48:54 prplOS obuspa[1696]:          value: "4.4.4.4"
 2025 Feb 21 08:48:54 prplOS obuspa[1696]:          required: true
 2025 Feb 21 08:48:54 prplOS obuspa[1696]:        }
 2025 Feb 21 08:48:54 prplOS obuspa[1696]:      }
 2025 Feb 21 08:48:54 prplOS obuspa[1696]:    }
 2025 Feb 21 08:48:54 prplOS obuspa[1696]:  }
 2025 Feb 21 08:48:54 prplOS obuspa[1696]: }
When we run obuspa -c set on the device:
2025 Feb 21 08:49:56 prplOS obuspa[1696]: header {
 2025 Feb 21 08:49:56 prplOS obuspa[1696]:  msg_id: "BROKER-157-1740127796"
 2025 Feb 21 08:49:56 prplOS obuspa[1696]:  msg_type: SET
 2025 Feb 21 08:49:56 prplOS obuspa[1696]: }
 2025 Feb 21 08:49:56 prplOS obuspa[1696]: body {
 2025 Feb 21 08:49:56 prplOS obuspa[1696]:  request {
 2025 Feb 21 08:49:56 prplOS obuspa[1696]:    set {
 2025 Feb 21 08:49:56 prplOS obuspa[1696]:      allow_partial: false
 2025 Feb 21 08:49:56 prplOS obuspa[1696]:      update_objs {
 2025 Feb 21 08:49:56 prplOS obuspa[1696]:        obj_path: "Device.Time.Client.1."
 2025 Feb 21 08:49:56 prplOS obuspa[1696]:        param_settings {
 2025 Feb 21 08:49:56 prplOS obuspa[1696]:          param: "Servers"
 2025 Feb 21 08:49:56 prplOS obuspa[1696]:          value: "4.4.4.4"
 2025 Feb 21 08:49:56 prplOS obuspa[1696]:          required: true
 2025 Feb 21 08:49:56 prplOS obuspa[1696]:        }
 2025 Feb 21 08:49:56 prplOS obuspa[1696]:      }
 2025 Feb 21 08:49:56 prplOS obuspa[1696]:    }
 2025 Feb 21 08:49:56 prplOS obuspa[1696]:  }
 2025 Feb 21 08:49:56 prplOS obuspa[1696]: }