### PR TITLE
Remove unnecessary .. from Docker files

### DIFF
--- a/backend/services/acs/build/Dockerfile
+++ b/backend/services/acs/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.23 as builder
 WORKDIR /app
-COPY ../ .
+COPY ./ .
 RUN CGO_ENABLED=0 GOOS=linux go build -o acs cmd/acs/main.go
 
 FROM alpine:3.14@sha256:0f2d5c38dd7a4f4f733e688e3a6733cb5ab1ac6e3cb4603a5dd564e5bfb80eed

--- a/backend/services/bulkdata/http/build/Dockerfile
+++ b/backend/services/bulkdata/http/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.22@sha256:82e07063a1ac3ee59e6f38b1222e32ce88469e4431ff6496cc40fb9a0fc18229 as builder
 WORKDIR /app
-COPY ../ .
+COPY ./ .
 RUN CGO_ENABLED=0 GOOS=linux go build -o http-bulk-collector cmd/http-bulk-collector/main.go
 
 FROM alpine:3.14@sha256:0f2d5c38dd7a4f4f733e688e3a6733cb5ab1ac6e3cb4603a5dd564e5bfb80eed

--- a/backend/services/controller/build/Dockerfile
+++ b/backend/services/controller/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.23 as builder
 WORKDIR /app
-COPY ../ .
+COPY ./ .
 RUN CGO_ENABLED=0 GOOS=linux go build -o controller cmd/controller/main.go
 
 FROM alpine:3.14@sha256:0f2d5c38dd7a4f4f733e688e3a6733cb5ab1ac6e3cb4603a5dd564e5bfb80eed

--- a/backend/services/mtp/adapter/build/Dockerfile
+++ b/backend/services/mtp/adapter/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.23 as builder
 WORKDIR /app
-COPY ../ .
+COPY ./ .
 RUN CGO_ENABLED=0 GOOS=linux go build -o adapter cmd/adapter/main.go
 
 FROM alpine:3.14@sha256:0f2d5c38dd7a4f4f733e688e3a6733cb5ab1ac6e3cb4603a5dd564e5bfb80eed

--- a/backend/services/mtp/mqtt-adapter/build/Dockerfile
+++ b/backend/services/mtp/mqtt-adapter/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.23 as builder
 WORKDIR /app
-COPY ../ .
+COPY ./ .
 RUN CGO_ENABLED=0 GOOS=linux go build -o mqtt-adapter cmd/mqtt-adapter/main.go
 
 FROM alpine:3.14@sha256:0f2d5c38dd7a4f4f733e688e3a6733cb5ab1ac6e3cb4603a5dd564e5bfb80eed

--- a/backend/services/mtp/mqtt/build/Dockerfile
+++ b/backend/services/mtp/mqtt/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.23 as builder
 WORKDIR /app
-COPY ../ .
+COPY ./ .
 RUN CGO_ENABLED=0 GOOS=linux go build -o mqtt cmd/mqtt/main.go
 
 FROM alpine:3.14@sha256:0f2d5c38dd7a4f4f733e688e3a6733cb5ab1ac6e3cb4603a5dd564e5bfb80eed

--- a/backend/services/mtp/stomp-adapter/build/Dockerfile
+++ b/backend/services/mtp/stomp-adapter/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.23 as builder
 WORKDIR /app
-COPY ../ .
+COPY ./ .
 RUN CGO_ENABLED=0 GOOS=linux go build -o stomp-adapter cmd/stomp-adapter/main.go
 
 FROM alpine:3.14@sha256:0f2d5c38dd7a4f4f733e688e3a6733cb5ab1ac6e3cb4603a5dd564e5bfb80eed

--- a/backend/services/mtp/stomp/build/Dockerfile
+++ b/backend/services/mtp/stomp/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.22@sha256:82e07063a1ac3ee59e6f38b1222e32ce88469e4431ff6496cc40fb9a0fc18229 as builder
 WORKDIR /app
-COPY ../ .
+COPY ./ .
 RUN CGO_ENABLED=0 GOOS=linux go build -o stomp cmd/stomp/main.go
 
 FROM alpine:3.14@sha256:0f2d5c38dd7a4f4f733e688e3a6733cb5ab1ac6e3cb4603a5dd564e5bfb80eed

--- a/backend/services/mtp/ws-adapter/build/Dockerfile
+++ b/backend/services/mtp/ws-adapter/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.23 as builder
 WORKDIR /app
-COPY ../ .
+COPY ./ .
 RUN CGO_ENABLED=0 GOOS=linux go build -o ws-adapter cmd/ws-adapter/main.go
 
 FROM alpine:3.14@sha256:0f2d5c38dd7a4f4f733e688e3a6733cb5ab1ac6e3cb4603a5dd564e5bfb80eed

--- a/backend/services/mtp/ws/build/Dockerfile
+++ b/backend/services/mtp/ws/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.23 as builder
 WORKDIR /app
-COPY ../ .
+COPY ./ .
 RUN CGO_ENABLED=0 GOOS=linux go build -o ws cmd/ws/main.go
 
 FROM alpine:3.14@sha256:0f2d5c38dd7a4f4f733e688e3a6733cb5ab1ac6e3cb4603a5dd564e5bfb80eed

--- a/backend/services/utils/file-server/build/Dockerfile
+++ b/backend/services/utils/file-server/build/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.22.2@sha256:450e3822c7a135e1463cd83e51c8e2eb03b86a02113c89424e6f0f8344bb4168 as builder
 WORKDIR /app
-COPY ../ .
+COPY ./ .
 RUN CGO_ENABLED=0 GOOS=linux go build -o file-server main.go
 
 FROM alpine:3.14@sha256:0f2d5c38dd7a4f4f733e688e3a6733cb5ab1ac6e3cb4603a5dd564e5bfb80eed

--- a/backend/services/utils/socketio/build/Dockerfile
+++ b/backend/services/utils/socketio/build/Dockerfile
@@ -2,10 +2,10 @@ FROM node:16.20.2-alpine
 
 WORKDIR /app
 
-COPY ../package*.json ./
+COPY ./package*.json ./
 
 RUN npm install
 
-COPY ../ .
+COPY ./ .
 
 CMD ["node", "server.js"]

--- a/frontend/build/Dockerfile
+++ b/frontend/build/Dockerfile
@@ -2,7 +2,7 @@ FROM node:18.18.0-alpine as builder
 
 WORKDIR /app
 
-COPY ../ ./
+COPY ./ .
 RUN rm .env && rm .env.local || true
 
 RUN npm install 


### PR DESCRIPTION
Since '..' is already passed as docker build context in the Makefiles, many of the '..' in the corresponding Dockerfiles are unnecessary and cause the docker build command to fail with the following error: COPY failed: forbidden path outside the build context: ../ ()

This commit removes all the unnecessary '..' from Docker files and fixes the build

fixes #379