### PR TITLE
Open 8081 port in the WS container

### DIFF
--- a/deploy/compose/docker-compose.yaml
+++ b/deploy/compose/docker-compose.yaml
@@ -72,6 +72,7 @@ services:
     container_name: websockets
     ports:
       - 8080:8080
+      - 8081:8081
     env_file:
       - .env.ws
     volumes:


### PR DESCRIPTION
Since the container by default support TLS on port 8081, the docker compose yaml file should make that port open by default.

Fixes #381
