### PR TITLE
fix(frontend): fix command input arguments

### DIFF
--- a/frontend/src/sections/devices/usp/devices-discovery.js
+++ b/frontend/src/sections/devices/usp/devices-discovery.js
@@ -984,9 +984,7 @@ const getDeviceParameterInstances = async (raw) =>{
                                         {
                                             [x.supported_obj_path+y.command_name]:
                                             {"input_arg_names":
-                                                [
-                                                    y.input_arg_names
-                                                ]
+                                                y.input_arg_names
                                             }
                                         }
                                     )

--- a/frontend/src/sections/devices/usp/devices-discovery.js
+++ b/frontend/src/sections/devices/usp/devices-discovery.js
@@ -214,7 +214,8 @@ function ShowParamsWithValues({
     setParameterValue, deviceParameters, 
     setShowLoading, router,
     updateDeviceParameters, deviceCommands,
-    openCommandDialog
+    openCommandDialog, setDeviceCommandToExecute,
+    setOpenCommandDialog
 }) {
     console.log("HEY jow:", deviceParametersValue)
     let paths = x.supported_obj_path.split(".")
@@ -324,7 +325,17 @@ function ShowParamsWithValues({
                             pl: 4 
                         }}
                         secondaryAction={
-                            <IconButton>
+                            <IconButton onClick={()=>{
+                                setDeviceCommandToExecute(
+                                    {
+                                        [paramKey+commando]:
+                                        {"input_arg_names":
+                                            deviceCommands[commando].input_arg_names
+                                        }
+                                    }
+                                )
+                                setOpenCommandDialog(true)
+                                }}>
                                 <SvgIcon>
                                     <PlayCircleIcon>
                                     </PlayCircleIcon>
@@ -404,7 +415,17 @@ function ShowParamsWithValues({
                             pl: 4 
                         }}
                         secondaryAction={
-                            <IconButton>
+                            <IconButton onClick={()=>{
+                                setDeviceCommandToExecute(
+                                    {
+                                        [x.supported_obj_path+commando]:
+                                        {"input_arg_names":
+                                            deviceCommands[commando].input_arg_names
+                                        }
+                                    }
+                                )
+                                setOpenCommandDialog(true)
+                                }}>
                                 <SvgIcon>
                                     <PlayCircleIcon>
                                     </PlayCircleIcon>
@@ -727,7 +748,8 @@ const getDeviceParameterInstances = async (raw) =>{
         for(let i =0; i < supportedCommands.length; i++){
             let command = supportedCommands[i]
             commandsInfo[command.command_name] = {
-                "type":command["command_type"]
+                "type":command["command_type"],
+                "input_arg_names": command["input_arg_names"]
             }
         }
 
@@ -936,6 +958,8 @@ const getDeviceParameterInstances = async (raw) =>{
                     updateDeviceParameters={updateDeviceParameters}
                     deviceCommands={deviceCommands}
                     openCommandDialog={openCommandDialog}
+                    setDeviceCommandToExecute={setDeviceCommandToExecute}
+                    setOpenCommandDialog={setOpenCommandDialog}
                     />
                 }
                 { x.supported_commands && Object.keys(deviceCommands).length == 0 &&


### PR DESCRIPTION
Command input arguments are currently wrapped in another array resulting in one input field for all arguments, e.g. CauseReason instead of separate fields Cause and Reason.
<img width="284" height="159" alt="Screenshot 2026-06-08 at 11-18-23 Oktopus Controller" src="https://github.com/user-attachments/assets/b1d180bd-abe3-4bd7-8538-623296a1871b" />

This pr fixes the above issue and implements the same features for device commands as for supported commands.