### PR TITLE
chore: update Dockerfile base image to Ubuntu 24.04 LTS

### DIFF
--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -3,8 +3,8 @@
 #
 # Base docker image with all required dependencies for OB-USP-A
 #
-# Based on Ubuntu 22.10 (Kinetic Kudu), which provides libmosquitto 2.0.11 and libwebsockets 4.1.6
-# This image includes some basic compilation tools (automake, autoconf)
+# Based on Ubuntu 24.04 LTS (Noble Numbat) - long-term support until 2029
+# This image includes libmosquitto, libwebsockets and basic compilation tools (automake, autoconf)
 #
 # One-liner execution line (straightforward build for OB-USP-A execution):
 # > docker build -f Dockerfile -t obuspa:latest .
@@ -15,7 +15,7 @@
 # 2) Create the OB-USP-A image, then build the application
 # > docker build -f Dockerfile -t obuspa:latest --target runner .
 #
-FROM ubuntu:lunar AS build-env
+FROM ubuntu:24.04 AS build-env
 
 # Install dependencies
 RUN apt-get update && apt-get -y install \
@@ -27,21 +27,10 @@ RUN apt-get update && apt-get -y install \
         automake \
         libtool \
         libmosquitto-dev \
+        libwebsockets-dev \
         pkg-config \
         make \
-        git \
-        cmake \
-        g++ \
     && apt-get clean
-
-RUN git clone https://github.com/warmcat/libwebsockets.git /tmp/libwebsockets && \
-    cd /tmp/libwebsockets && \
-    mkdir build && \
-    cd build && \
-    cmake .. && \
-    make && \
-    make install && \
-    ldconfig
 
 FROM build-env AS runner
 
@@ -60,6 +49,10 @@ RUN cd /obuspa/ && \
 # Then delete the code
 # that's no longer needed
 RUN rm -rf /obuspa
+
+# Create database directory and set permissions
+RUN mkdir -p /usr/local/var/obuspa && \
+    chmod 755 /usr/local/var/obuspa
 
 # Run obuspa with args expanded
 CMD obuspa ${OBUSPA_ARGS}


### PR DESCRIPTION
## Summary
Update the obuspa build image from Ubuntu lunar to Ubuntu 24.04 LTS (Noble Numbat).

Fixes #400

## Motivation
1. Ubuntu lunar is EOL : The lunar release repositories are no longer maintained, causing apt-get update to return 404 errors and breaking the build.
2. Documentation mismatch : The comments mentioned Ubuntu 22.10 but the actual base image was ubuntu:lunar , creating confusion.
## Changes
- ✅ Base image changed from ubuntu:lunar to ubuntu:24.04
- ✅ Updated comments to reflect Ubuntu 24.04 LTS support until 2029
- ✅ Install libwebsockets-dev via apt instead of building from source
- ✅ Removed unnecessary build dependencies (git, cmake, g++)
- ✅ Added database directory creation to prevent sqlite3 initialization errors
## Testing
- Docker image builds successfully
- apt-get install libwebsockets-dev is available
- obuspa compiles successfully
- obuspa starts without sqlite3 database path errors
## Test Logs
Successful startup log after the fix:
```
DATABASE_Init: Opening database /usr/local/var/obuspa/usp.db

OpenUspDatabase: Unable to stat() USP database file /usr/local/var/obuspa/usp.db (errno=2, No such file or directory)

ReInitializeDatabase: Reinitializing USP database (/usr/local/var/obuspa/usp.db)

ResetFactoryParametersFromFile: Setting factory reset parameters

LoadClientCert: Not using a device certificate for connections

LoadTrustStore_FromMutableCertDir: Creating mutable cert dir(=/usr/local/var/obuspa/mutable_certs)

Attempting to connect to host=127.0.0.1 (port=1883, unencrypted)
```
## Impact
Only affects agent/Dockerfile , no impact on other services. 