### PR TITLE
fix: add bounds check in GetDataModelType to prevent panic on empty ParameterList

### DIFF
--- a/backend/services/acs/internal/cwmp/cwmp.go
+++ b/backend/services/acs/internal/cwmp/cwmp.go
@@ -119,6 +119,9 @@ func (i *CWMPInform) GetHardwareVersion() string {
 }
 
 func (i *CWMPInform) GetDataModelType() string {
+	if len(i.ParameterList) == 0 {
+		return "TR181"
+	}
 	if strings.HasPrefix(i.ParameterList[0].Name, "InternetGatewayDevice") {
 		return "TR098"
 	} else if strings.HasPrefix(i.ParameterList[0].Name, "Device") {


### PR DESCRIPTION
Adds bounds check before accessing ParameterList[0]. Defaults to TR181 when empty. Fixes #403