### PR TITLE
fix(mtp): MQTT 3.1.1 agent compatibility for mqtt broker and mqtt-adapter

### DIFF
--- a/backend/services/mtp/adapter/internal/events/usp_handler/info.go
+++ b/backend/services/mtp/adapter/internal/events/usp_handler/info.go
@@ -48,7 +48,24 @@ func parseDeviceInfoMsg(sn, subject string, data []byte, mtp db.MTP) db.Device {
         return db.Device{}
     }
 
-    err = proto.Unmarshal(record.GetNoSessionContext().Payload, &message)
+    noSessionCtx := record.GetNoSessionContext()
+    if noSessionCtx == nil || noSessionCtx.Payload == nil {
+        log.Printf("Record has no NoSessionContext payload (record type: %T) - registering device with basic info", record.RecordType)
+        var device db.Device
+        device.SN = sn
+        switch db.MTP(mtp) {
+        case db.MQTT:
+            device.Mqtt = db.Online
+        case db.WEBSOCKETS:
+            device.Websockets = db.Online
+        case db.STOMP:
+            device.Stomp = db.Online
+        }
+        device.Status = db.Online
+        return device
+    }
+
+    err = proto.Unmarshal(noSessionCtx.Payload, &message)
     if err != nil {
         log.Println("Error unmarshaling USP Message:", err)
         return db.Device{}

--- a/backend/services/mtp/mqtt-adapter/internal/bridge/bridge.go
+++ b/backend/services/mtp/mqtt-adapter/internal/bridge/bridge.go
@@ -112,7 +112,7 @@ func (b *Bridge) natsMessageHandler(cm *autopaho.ConnectionManager) {
 		log.Printf("Received message on info subject")
 		cm.Publish(b.Ctx, &paho.Publish{
 			QoS:     byte(b.Mqtt.Qos),
-			Topic:   MQTT_TOPIC_PREFIX + "v1/agent/" + getDeviceFromSubject(m.Subject),
+			Topic:   resolveAgentTopic(getDeviceFromSubject(m.Subject)),
 			Payload: m.Data,
 			Properties: &paho.PublishProperties{
 				ResponseTopic: "oktopus/usp/v1/controller/" + getDeviceFromSubject(m.Subject),
@@ -124,12 +124,17 @@ func (b *Bridge) natsMessageHandler(cm *autopaho.ConnectionManager) {
 	b.Sub(NATS_MQTT_ADAPTER_SUBJECT_PREFIX+"*.api", func(m *nats.Msg) {
 
 		log.Printf("Received message on api subject")
+		// MQTT 3.1.1 agents cannot see the MQTT5 ResponseTopic property, so
+		// also embed it as a reply-to= topic suffix; obuspa parses that and
+		// publishes its response onto the api path instead of the controller
+		// topic (which would route to .info and never reach the API waiter).
+		apiRespTopic := "oktopus/usp/v1/api/" + getDeviceFromSubject(m.Subject)
 		cm.Publish(b.Ctx, &paho.Publish{
 			QoS:     byte(b.Mqtt.Qos),
-			Topic:   MQTT_TOPIC_PREFIX + "v1/agent/" + getDeviceFromSubject(m.Subject),
+			Topic:   resolveAgentTopic(getDeviceFromSubject(m.Subject)) + "/reply-to=" + url.QueryEscape(apiRespTopic),
 			Payload: m.Data,
 			Properties: &paho.PublishProperties{
-				ResponseTopic: "oktopus/usp/v1/api/" + getDeviceFromSubject(m.Subject),
+				ResponseTopic: apiRespTopic,
 			},
 		})
 
@@ -163,15 +168,29 @@ func getDeviceFromSubject(subject string) string {
 	return device
 }
 
+// resolveAgentTopic maps a NATS-subject device segment to the MQTT agent
+// topic. MQTT 3.1.1 agents encode their response topic as a
+// "reply-to=<url-encoded topic>" segment (no MQTT5 Response Topic
+// property); decode it instead of publishing to a literal reply-to= topic.
+func resolveAgentTopic(device string) string {
+	if strings.HasPrefix(device, "reply-to=") {
+		decoded, err := url.QueryUnescape(strings.TrimPrefix(device, "reply-to="))
+		if err == nil {
+			return decoded
+		}
+	}
+	return MQTT_TOPIC_PREFIX + "v1/agent/" + device
+}
+
 func (b *Bridge) mqttMessageHandler(status, controller, apiMsg chan *paho.Publish) {
 	for {
 		select {
 		case d := <-status:
-			b.Pub(NATS_MQTT_SUBJECT_PREFIX+getDeviceFromTopic(d.Topic)+".status", d.Payload)
+			b.Pub(NATS_MQTT_SUBJECT_PREFIX+resolveDeviceFromTopic(d.Topic)+".status", d.Payload)
 		case c := <-controller:
-			b.Pub(NATS_MQTT_SUBJECT_PREFIX+getDeviceFromTopic(c.Topic)+".info", c.Payload)
+			b.Pub(NATS_MQTT_SUBJECT_PREFIX+resolveDeviceFromTopic(c.Topic)+".info", c.Payload)
 		case a := <-apiMsg:
-			b.Pub(DEVICE_SUBJECT_PREFIX+getDeviceFromTopic(a.Topic)+".api", a.Payload)
+			b.Pub(DEVICE_SUBJECT_PREFIX+resolveDeviceFromTopic(a.Topic)+".api", a.Payload)
 		}
 	}
 }
@@ -179,6 +198,21 @@ func (b *Bridge) mqttMessageHandler(status, controller, apiMsg chan *paho.Publis
 func getDeviceFromTopic(topic string) string {
 	paths := strings.Split(topic, "/")
 	device := paths[len(paths)-1]
+	return device
+}
+
+// resolveDeviceFromTopic extracts the clean endpoint ID from an incoming
+// MQTT topic whose last segment may be an MQTT 3.1.1
+// "reply-to=<url-encoded agent topic>" marker.
+func resolveDeviceFromTopic(topic string) string {
+	device := getDeviceFromTopic(topic)
+	if strings.HasPrefix(device, "reply-to=") {
+		decoded, err := url.QueryUnescape(strings.TrimPrefix(device, "reply-to="))
+		if err == nil {
+			parts := strings.Split(decoded, "/")
+			return parts[len(parts)-1]
+		}
+	}
 	return device
 }
 
@@ -195,6 +229,17 @@ func subscribe(ctx context.Context, qos int, c *autopaho.ConnectionManager) {
 			},
 			{
 				Topic: MQTT_TOPIC_PREFIX + "+/status/+",
+				QoS:   byte(qos),
+			},
+			// MQTT 3.1.1 agents append a "/reply-to=<encoded topic>" level to
+			// the topics they publish responses on, one level deeper than the
+			// filters above — subscribe those too or agent replies are lost.
+			{
+				Topic: MQTT_TOPIC_PREFIX + "+/api/+/+",
+				QoS:   byte(qos),
+			},
+			{
+				Topic: MQTT_TOPIC_PREFIX + "+/controller/+/+",
 				QoS:   byte(qos),
 			},
 		},

--- a/backend/services/mtp/mqtt/internal/listeners/mqtt/hook.go
+++ b/backend/services/mtp/mqtt/internal/listeners/mqtt/hook.go
@@ -49,6 +49,8 @@ func (h *MyHook) OnDisconnect(cl *mqtt.Client, err error, expire bool) {
 	var clUser string
 	if len(cl.Properties.Props.User) > 0 {
 		clUser = cl.Properties.Props.User[0].Val
+	} else {
+		clUser = cl.ID // MQTT 3.1.1 fallback: no User Properties, use client ID
 	}
 
 	if clUser != "" {
@@ -66,6 +68,8 @@ func (h *MyHook) OnSubscribed(cl *mqtt.Client, pk packets.Packet, reasonCodes []
 
 		if len(cl.Properties.Props.User) > 0 {
 			clUser = cl.Properties.Props.User[0].Val
+		} else {
+			clUser = cl.ID // MQTT 3.1.1 fallback: no User Properties, use client ID
 		}
 
 		if clUser != "" {


### PR DESCRIPTION
## Problem

MQTT **3.1.1** USP agents (e.g. OB-USP-Agent / obuspa configured with `ProtocolVersion 3.1.1`) can't use the MQTT 5.0 `Response Topic` or `User Properties` features. Per the USP MQTT binding, they instead encode the reply topic as a `reply-to=<url-encoded topic>` suffix appended to the publish topic. Against current `dev`, such an agent connects to the broker but cannot complete any USP exchange:

- the adapter panics (nil pointer) on the agent's initial `MqttConnect` record;
- the broker's online/offline status events never publish (they rely on MQTT5 User Properties), so auto-discovery never fires;
- the literal string `reply-to=...` leaks into NATS subjects and MongoDB device IDs;
- API requests (Get/Set/...) always time out: agents answer on their controller topic with a `reply-to=` suffix, which is both the wrong routing path for the API waiter **and** one topic level deeper than the bridge's subscription filters, so the reply is silently never delivered.

## Fixes (all in this PR, one per bullet)

- **adapter**: guard nil `NoSessionContext` when parsing device-info records; `Record_MqttConnect` has no payload — register the device with basic info instead of panicking.
- **mqtt broker**: in `OnSubscribed`/`OnDisconnect`, fall back to the MQTT client ID when no MQTT5 User Properties are present, so 3.1.1 devices still get status events (client ID is the agent's configured `ClientID`).
- **mqtt-adapter**: decode `reply-to=` segments when extracting the device ID from incoming topics, and when resolving the agent topic for outgoing publishes.
- **mqtt-adapter**: embed the api response topic as a `reply-to=` suffix on downlink publishes (3.1.1 agents can't see the MQTT5 `ResponseTopic` property) so agent replies route back to the API waiter.
- **mqtt-adapter**: subscribe additionally to `oktopus/usp/+/api/+/+` and `oktopus/usp/+/controller/+/+` — agent replies carry the `reply-to=` suffix as an extra topic level, one deeper than the existing filters.

MQTT 5.0 agents are unaffected: User Properties still take precedence in the broker hooks, the MQTT5 `ResponseTopic` property is still set, and the extra subscriptions/decoding only engage when a `reply-to=` segment is actually present.

## Testing

Validated end-to-end against a real OB-USP-Agent (obuspa) in MQTT 3.1.1 mode on Linksys router hardware, with the compose stack (`nats controller adapter mqtt frontend` profiles):

- device auto-registers with a clean endpoint ID (no `reply-to=` artifacts in MongoDB);
- USP **Get** round-trip returns live parameter values; **Set** applies and returns `OperSuccess`;
- a `ValueChange` subscription Notify (triggered by a controller-side Set) was captured delivering through broker → mqtt-adapter → NATS;
- all three services build clean (`docker build` on each service's `build/Dockerfile`).

Happy to split this into separate PRs per service if you prefer.